### PR TITLE
Get a working hellospark.py.

### DIFF
--- a/helloworld/sparkjob/BUILD
+++ b/helloworld/sparkjob/BUILD
@@ -1,5 +1,11 @@
 python_sources()
 
+pex_binary(
+    name="main",
+    entry_point="hellospark.py",
+    execution_mode="venv"
+)
+
 python_tests(
     name="tests",
 )


### PR DESCRIPTION
```
$ pants run helloworld/sparkjob:main
23/01/22 13:44:10 WARN Utils: Your hostname, Gill-Windows resolves to a loopback address: 127.0.1.1; using 172.19.67.59 instead (on interface eth0)
23/01/22 13:44:10 WARN Utils: Set SPARK_LOCAL_IP if you need to bind to another address
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
23/01/22 13:44:11 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
[Row(id=1, mean_udf(v)=1.5), Row(id=2, mean_udf(v)=6.0)]
```